### PR TITLE
jtag/drivers/bcm2835gpio: Ignore drive settings of input pins on init

### DIFF
--- a/src/jtag/drivers/bcm2835gpio.c
+++ b/src/jtag/drivers/bcm2835gpio.c
@@ -245,7 +245,8 @@ static void initialize_gpio(enum adapter_gpio_config_index idx)
 	}
 
 	/* Direction for non push-pull is already set by set_gpio_value() */
-	if (adapter_gpio_config[idx].drive == ADAPTER_GPIO_DRIVE_MODE_PUSH_PULL)
+	if (adapter_gpio_config[idx].drive == ADAPTER_GPIO_DRIVE_MODE_PUSH_PULL &&
+		adapter_gpio_config[idx].init_state != ADAPTER_GPIO_INIT_STATE_INPUT)
 		OUT_GPIO(adapter_gpio_config[idx].gpio_num);
 	bcm2835_gpio_synchronize();
 }


### PR DESCRIPTION
Input GPIOs were being incorrectly reset to outputs because of faulty logic with push-pull optimizations. This commit will only check pins configured as init-active or init-inactive when initializing push-pull to outputs.